### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,20 @@ on:
     - cron: "0 7 * * 1"
 
 jobs:
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code formatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --format-prettier
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@
 name: ci
 
 on:
+
+lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ lint-yamllint:
           pip install yamllint
           ./run-tests.sh --lint-yamllint
 
+format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,13 @@
 name: ci
 
 on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 7 * * 1"
 
-lint-yamllint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Lint YAML files
-        run: |
-          pip install yamllint
-          ./run-tests.sh --lint-yamllint
-
-format-shfmt:
+jobs:
+  format-shfmt:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -37,12 +24,6 @@ format-shfmt:
           sudo apt-get install shfmt
           ./run-tests.sh --format-shfmt
 
-  push:
-  pull_request:
-  schedule:
-    - cron: "0 7 * * 1"
-
-jobs:
   lint-commitlint:
     runs-on: ubuntu-24.04
     steps:
@@ -69,6 +50,20 @@ jobs:
         run: |
           ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
   lint-shellcheck:
     runs-on: ubuntu-24.04
     steps:
@@ -80,16 +75,21 @@ jobs:
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
 
-  validate:
+  lint-yamllint:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate workflow spec
-        uses: reanahub/reana-github-actions/local-validate@v1
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          reana_specs: reana.yaml
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
 
   local-run:
     runs-on: ubuntu-24.04
@@ -109,3 +109,14 @@ jobs:
             ls -l `pwd`/AnalysisResults.root
             ls -l `pwd`/plot_pt.pdf
             ls -l `pwd`/plot_eta.pdf
+
+  validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate workflow spec
+        uses: reanahub/reana-github-actions/local-validate@v1
+        with:
+          reana_specs: reana.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 # This file is part of REANA.
-# Copyright (C) 2022, 2023, 2024 CERN.
+# Copyright (C) 2022, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on:
   push:
@@ -32,12 +32,12 @@ jobs:
       - name: Check commit message compliance of the recently pushed commit
         if: github.event_name == 'push'
         run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
 
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
     runs-on: ubuntu-24.04
@@ -48,7 +48,7 @@ jobs:
       - name: Runs shell script static analysis
         run: |
           sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
+          ./run-tests.sh --lint-shellcheck
 
   validate:
     runs-on: ubuntu-24.04

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,7 @@
-# Allow long lines (to be fixed when prettier is added)
-MD013: false
+# Allow long lines in code blocks and tables
+MD013:
+  code_blocks: false
+  tables: false
 # Allow prompt dollar sign in console examples without showing output
 MD014: false
 # Allow flexible list spacing

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+# Allow long lines (to be fixed when prettier is added)
+MD013: false
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+# Allow flexible list spacing
+MD032: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,8 @@
 extends: default
 
 rules:
+  braces:
+    max-spaces-inside: 1
   comments:
     min-spaces-from-content: 1
   document-start: disable

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ environment that is not publicly available.
 
 ALICE physicists use custom tools that facilitate the analysis of real or
 simulated ALICE data samples. This example demonstrates the use of the ALICE
-analysis framework on small samples of both pp and PbPb data taken in the year
-2010.
+analysis framework on small samples of both pp and PbPb data taken in the
+year 2010.
 
 ## Analysis structure
 
@@ -33,11 +33,11 @@ cloud and run the analysis to obtain (5) output results.
 
 The analysis uses (i) an ALICE ESD data file for either pp or PbPb collisions
 and (ii) an ODCB magnet configuration database. For the ESD data file, let us
-take an example that was published by the ALICE collaboration on the [CERN Open
-Data portal](http://opendata.cern.ch/) from Pb-Pb collisions. Here, we use the
-sample at 3.5 TeV from run number 139038 in RunH 2010. We select the third
-(0003) file that is about 360 MB large in order to have a reasonable number of
-events for the example.
+take an example that was published by the ALICE collaboration on the
+[CERN Open Data portal](http://opendata.cern.ch/) from Pb-Pb collisions. Here,
+we use the sample at 3.5 TeV from run number 139038 in RunH 2010. We select the
+third (0003) file that is about 360 MB large in order to have a reasonable
+number of events for the example.
 
 ```console
 $ mkdir -p data
@@ -64,13 +64,14 @@ framework with the following source code files:
 
 - [fix-env.sh](fix-env.sh) - to fix the configuration environment variables
 - [runEx01.C](runEx01.C) - the main analysis script
-- [plot.C](plot.C) - script to extract data and plot the figures from the resulting ROOT
-  file
+- [plot.C](plot.C) - script to extract data and plot the figures from the
+  resulting ROOT file
 
-- [AliAnalysisTaskEx01.cxx](AliAnalysisTaskEx01.cxx) - the example script analysing the
-  Pt spectrum
+- [AliAnalysisTaskEx01.cxx](AliAnalysisTaskEx01.cxx) - the example script
+  analysing the Pt spectrum
 
-- [AliAnalysisTaskEx01.h](AliAnalysisTaskEx01.h) - ROOT library for customization
+- [AliAnalysisTaskEx01.h](AliAnalysisTaskEx01.h) - ROOT library for
+  customization
 
 ### 3. Compute environment
 
@@ -195,11 +196,12 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1'
+      - environment: "docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1"
         commands:
-        - mkdir -p ./data && curl -fsS --retry 9 -o ./data/AliESDs.root ${data_location}
-        - source fix-env.sh && root -b -q './runEx01.C' | tee run.log
-        - mkdir -p results && source fix-env.sh && root -b -q './plot.C'
+          - mkdir -p ./data && curl -fsS --retry 9 -o ./data/AliESDs.root
+            ${data_location}
+          - source fix-env.sh && root -b -q './runEx01.C' | tee run.log
+          - mkdir -p results && source fix-env.sh && root -b -q './plot.C'
 outputs:
   files:
     - AnalysisResults.root

--- a/README.md
+++ b/README.md
@@ -7,36 +7,37 @@
 
 ## About
 
-This REANA reproducible analysis example demonstrates the use of the ALICE analysis
-framework to facilitate the analysis of ALICE collision and simulated data samples for
-both pp and PbPb data taken in the year 2010. The example was taken from an
-[analysis example](http://opendata.cern.ch/record/1200) from the
-[CERN Open Data portal](http://opendata.cern.ch/) and illustrates how to convert it into
-a reusable analysis (REANA) example, as it uses a complex computing
+This REANA reproducible analysis example demonstrates the use of the ALICE
+analysis framework to facilitate the analysis of ALICE collision and simulated
+data samples for both pp and PbPb data taken in the year 2010. The example was
+taken from an [analysis example](http://opendata.cern.ch/record/1200) from the
+[CERN Open Data portal](http://opendata.cern.ch/) and illustrates how to convert
+it into a reusable analysis (REANA) example, as it uses a complex computing
 environment that is not publicly available.
 
-ALICE physicists use custom tools that facilitate the analysis of real or simulated ALICE
-data samples. This example demonstrates the use of the ALICE analysis framework on small
-samples of both pp and PbPb data taken in the year 2010.
+ALICE physicists use custom tools that facilitate the analysis of real or
+simulated ALICE data samples. This example demonstrates the use of the ALICE
+analysis framework on small samples of both pp and PbPb data taken in the year
+2010.
 
 ## Analysis structure
 
-Making a research data analysis reproducible basically means to provide "runnable
-recipes" addressing (1) where is the input data, (2) what software was used to analyse
-the data, (3) which computing environments were used to run the software and (4) which
-computational workflow steps were taken to run the analysis. This will permit to
-instantiate the analysis on the computational cloud and run the analysis to obtain (5)
-output results.
+Making a research data analysis reproducible basically means to provide
+"runnable recipes" addressing (1) where is the input data, (2) what software was
+used to analyse the data, (3) which computing environments were used to run the
+software and (4) which computational workflow steps were taken to run the
+analysis. This will permit to instantiate the analysis on the computational
+cloud and run the analysis to obtain (5) output results.
 
 ### 1. Input data
 
-The analysis uses (i) an ALICE ESD data file for either pp or PbPb collisions and (ii) an
-ODCB magnet configuration database. For the ESD data file, let us take an example that
-was published by the ALICE collaboration on the
-[CERN Open Data portal](http://opendata.cern.ch/) from Pb-Pb collisions. Here, we use the
-sample at 3.5 TeV from run number 139038 in RunH 2010. We select the third (0003) file
-that is about 360 MB large in order to have a reasonable number of events for the
-example.
+The analysis uses (i) an ALICE ESD data file for either pp or PbPb collisions
+and (ii) an ODCB magnet configuration database. For the ESD data file, let us
+take an example that was published by the ALICE collaboration on the [CERN Open
+Data portal](http://opendata.cern.ch/) from Pb-Pb collisions. Here, we use the
+sample at 3.5 TeV from run number 139038 in RunH 2010. We select the third
+(0003) file that is about 360 MB large in order to have a reasonable number of
+events for the example.
 
 ```console
 $ mkdir -p data
@@ -45,17 +46,18 @@ $ curl -O http://opendata.cern.ch/eos/opendata/alice/2010/LHC10h/000139038/ESD/0
 $ cd ..
 ```
 
-Note that `data.txt` file should contain the path to the downloaded sample data file.
+Note that `data.txt` file should contain the path to the downloaded sample data
+file.
 
-For the magnet configuration database, let us take the `OCDB.root` file released on the
-[CERN Open Data portal](http://opendata.cern.ch/record/1200)
+For the magnet configuration database, let us take the `OCDB.root` file released
+on the [CERN Open Data portal](http://opendata.cern.ch/record/1200)
 
 ### 2. Analysis code
 
-The user analysis is represented by a C++ class, which has to implement a few predefined
-methods to process one interaction event. A template analysis class extracting the
-inclusive transverse momentum and pseudorapidity spectra of all tracks can be modified to
-create your own analysis.
+The user analysis is represented by a C++ class, which has to implement a few
+predefined methods to process one interaction event. A template analysis class
+extracting the inclusive transverse momentum and pseudorapidity spectra of all
+tracks can be modified to create your own analysis.
 
 This example uses the [AliPhysics](https://github.com/alisw/AliPhysics) analysis
 framework with the following source code files:
@@ -64,16 +66,18 @@ framework with the following source code files:
 - [runEx01.C](runEx01.C) - the main analysis script
 - [plot.C](plot.C) - script to extract data and plot the figures from the resulting ROOT
   file
+
 - [AliAnalysisTaskEx01.cxx](AliAnalysisTaskEx01.cxx) - the example script analysing the
   Pt spectrum
+
 - [AliAnalysisTaskEx01.h](AliAnalysisTaskEx01.h) - ROOT library for customization
 
 ### 3. Compute environment
 
-This example uses [AliPhysics](https://github.com/alisw/AliPhysics) analysis framework.
-It has been containerised as
-[reana-env-aliphysics](https://github.com/reanahub/reana-env-aliphysics) environment. You
-can fetch some wanted AliPhysics version from Docker Hub:
+This example uses [AliPhysics](https://github.com/alisw/AliPhysics) analysis
+framework. It has been containerised as
+[reana-env-aliphysics](https://github.com/reanahub/reana-env-aliphysics)
+environment. You can fetch some wanted AliPhysics version from Docker Hub:
 
 ```console
 $ docker pull docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1
@@ -81,8 +85,9 @@ $ docker pull docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1
 
 We shall use the `vAN-20180614-1` version for the present example.
 
-Note that if you would like to build a different AliPhysics version on your own, you can
-follow [reana-env-aliphysics](https://github.com/reanahub/reana-env-aliphysics)
+Note that if you would like to build a different AliPhysics version on your own,
+you can follow
+[reana-env-aliphysics](https://github.com/reanahub/reana-env-aliphysics)
 procedures and set `ALIPHYSICS_VERSION` environment variable appropriately:
 
 ```console
@@ -93,11 +98,11 @@ $ make build
 
 ### 4. Analysis workflow
 
-This analysis example consists of a script to run the task using aliroot, and then plots
-the results.
+This analysis example consists of a script to run the task using aliroot, and
+then plots the results.
 
-The computational workflow is essentially sequential in nature. We can use the REANA
-serial workflow engine and represent the analysis workflow as follows:
+The computational workflow is essentially sequential in nature. We can use the
+REANA serial workflow engine and represent the analysis workflow as follows:
 
 ```console
                  START
@@ -135,42 +140,43 @@ serial workflow engine and represent the analysis workflow as follows:
                   STOP
 ```
 
-We shall see below how this sequence of commands is represented for the REANA serial
-workflow engine.
+We shall see below how this sequence of commands is represented for the REANA
+serial workflow engine.
 
 ### 5. Output results
 
-The test run will create [ROOT](https://root.cern.ch/) output files that usually contain
-histograms.
+The test run will create [ROOT](https://root.cern.ch/) output files that usually
+contain histograms.
 
 ```console
 $ ls -l AnalysisResults.root
 -rw-r--r-- 1 root root  31187 July 18 17:35 AnalysisResults.root
 ```
 
-The user typically uses the output files to produce final plots. For example, running
-`plot.C` output macro on the `AnalysisResults.root` output file will permit to visualise
-the pt distribution of the accepted events:
+The user typically uses the output files to produce final plots. For example,
+running `plot.C` output macro on the `AnalysisResults.root` output file will
+permit to visualise the pt distribution of the accepted events:
 
-![](https://raw.githubusercontent.com/reanahub/reana-demo-alice-pt-analysis/master/docs/plot_pt.png)
+![image](https://raw.githubusercontent.com/reanahub/reana-demo-alice-pt-analysis/master/docs/plot_pt.png)
 
-![](https://raw.githubusercontent.com/reanahub/reana-demo-alice-pt-analysis/master/docs/plot_eta.png)
+![image](https://raw.githubusercontent.com/reanahub/reana-demo-alice-pt-analysis/master/docs/plot_eta.png)
 
 ## Running the example on REANA cloud
 
 There are two ways to execute this analysis example on REANA.
 
-If you would like to simply launch this analysis example on the REANA instance at CERN
-and inspect its results using the web interface, please click on the following badge:
+If you would like to simply launch this analysis example on the REANA instance
+at CERN and inspect its results using the web interface, please click on the
+following badge:
 
 [![image](https://www.reana.io/static/img/badges/launch-on-reana-at-cern.svg)](https://reana.cern.ch/launch?url=https%3A%2F%2Fgithub.com%2Freanahub%2Freana-demo-alice-pt-analysis&name=reana-demo-alice-pt-analysis)
 
-If you would like a step-by-step guide on how to use the REANA command-line client to
-launch this analysis example, please read on.
+If you would like a step-by-step guide on how to use the REANA command-line
+client to launch this analysis example, please read on.
 
-We start by creating a [reana.yaml](reana.yaml) file describing the above analysis
-structure with its inputs, code, runtime environment, computational workflow steps and
-expected outputs:
+We start by creating a [reana.yaml](reana.yaml) file describing the above
+analysis structure with its inputs, code, runtime environment, computational
+workflow steps and expected outputs:
 
 ```yaml
 version: 0.3.0
@@ -201,8 +207,8 @@ outputs:
     - results/plot_eta.pdf
 ```
 
-We can now install the REANA command-line client, run the analysis and download the
-resulting plots:
+We can now install the REANA command-line client, run the analysis and download
+the resulting plots:
 
 ```console
 $ # create new virtual environment
@@ -228,5 +234,6 @@ $ # download results root file and generated plots
 $ reana-client download
 ```
 
-Please see the [REANA-Client](https://reana-client.readthedocs.io/) documentation for
-more detailed explanation of typical `reana-client` usage scenarios.
+Please see the [REANA-Client](https://reana-client.readthedocs.io/)
+documentation for more detailed explanation of typical `reana-client` usage
+scenarios.

--- a/reana.yaml
+++ b/reana.yaml
@@ -14,11 +14,12 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1'
+      - environment: "docker.io/reanahub/reana-env-aliphysics:vAN-20180614-1"
         commands:
-        - mkdir -p ./data && curl -fsS --retry 9 -o ./data/AliESDs.root ${data_location}
-        - source ./fix-env.sh && root -b -q './runEx01.C' | tee run.log
-        - source ./fix-env.sh && root -b -q './plot.C' | tee plot.log
+          - mkdir -p ./data && curl -fsS --retry 9 -o ./data/AliESDs.root
+            ${data_location}
+          - source ./fix-env.sh && root -b -q './runEx01.C' | tee run.log
+          - source ./fix-env.sh && root -b -q './plot.C' | tee plot.log
 outputs:
   files:
     - AnalysisResults.root

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,15 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -43,23 +47,34 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_all () {
-    check_commitlint
-    check_shellcheck
+all() {
+    lint_commitlint
+    lint_shellcheck
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all              Perform all checks [default]"
+    echo "  --help             Display this help message"
+    echo "  --lint-commitlint  Check linting of commit messages"
+    echo "  --lint-shellcheck  Check linting of shell scripts"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-shellcheck) lint_shellcheck ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_shfmt() {
+    shfmt -d .
+}
+
 lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
@@ -35,7 +39,7 @@ lint_commitlint() {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -56,6 +60,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_shfmt
     lint_commitlint
     lint_shellcheck
     lint_yamllint
@@ -65,6 +70,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all              Perform all checks [default]"
+    echo "  --format-shfmt     Check formatting of shell scripts"
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
@@ -80,6 +86,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_prettier() {
+    prettier -c .
+}
+
 format_shfmt() {
     shfmt -d .
 }
@@ -64,6 +68,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_prettier
     format_shfmt
     lint_commitlint
     lint_markdownlint
@@ -75,6 +80,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all                Perform all checks [default]"
+    echo "  --format-prettier    Check formatting of Markdown etc files"
     echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
@@ -92,6 +98,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-prettier) format_prettier ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-markdownlint) lint_markdownlint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,9 +51,14 @@ lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 all() {
     lint_commitlint
     lint_shellcheck
+    lint_yamllint
 }
 
 help() {
@@ -63,6 +68,7 @@ help() {
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
+    echo "  --lint-yamllint    Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -76,5 +82,6 @@ case $arg in
 --help) help ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,6 +51,10 @@ lint_commitlint() {
     fi
 }
 
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
@@ -62,6 +66,7 @@ lint_yamllint() {
 all() {
     format_shfmt
     lint_commitlint
+    lint_markdownlint
     lint_shellcheck
     lint_yamllint
 }
@@ -69,12 +74,13 @@ all() {
 help() {
     echo "Usage: $0 [options]"
     echo "Options:"
-    echo "  --all              Perform all checks [default]"
-    echo "  --format-shfmt     Check formatting of shell scripts"
-    echo "  --help             Display this help message"
-    echo "  --lint-commitlint  Check linting of commit messages"
-    echo "  --lint-shellcheck  Check linting of shell scripts"
-    echo "  --lint-yamllint    Check linting of YAML files"
+    echo "  --all                Perform all checks [default]"
+    echo "  --format-shfmt       Check formatting of shell scripts"
+    echo "  --help               Display this help message"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -88,6 +94,7 @@ case $arg in
 --help) help ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.