### PR TITLE
docs: update getting-started snippet for OIDC login

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ $ # install REANA client
 $ pip install reana-client
 $ # connect to some REANA cloud instance
 $ export REANA_SERVER_URL=https://reana.cern.ch/
-$ export REANA_ACCESS_TOKEN=XXXXXXX
+$ reana-client login
 $ # create new workflow
 $ reana-client create -n my-analysis
 $ export REANA_WORKON=my-analysis


### PR DESCRIPTION
Replaces exporting a long-lived REANA_ACCESS_TOKEN with `reana-client login`, matching the auth-rework OIDC/JWT change.

Closes: reanahub/reana#977